### PR TITLE
Fix design variance reference and skill lookup errors

### DIFF
--- a/skill.sh
+++ b/skill.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 # Local skill registry
+AVAILABLE_SKILLS="taste-skill gpt-taste image-to-code-skill imagegen-frontend-web imagegen-frontend-mobile brandkit redesign-skill soft-skill output-skill minimalist-skill brutalist-skill stitch-skill"
+
 declare -A SKILLS=(
   [taste-skill]="skills/taste-skill/SKILL.md"
   [gpt-taste]="skills/gpt-tasteskill/SKILL.md"
@@ -17,8 +19,13 @@ declare -A SKILLS=(
 )
 
 if [[ $# -eq 0 ]]; then
-  echo "Usage: source ./skill.sh <skill-name>"
-  echo "Available skills: ${!SKILLS[@]}"
+  echo "Usage: source ./skill.sh <skill-name>" >&2
+  echo "Available skills: $AVAILABLE_SKILLS" >&2
+  return 2 2>/dev/null || exit 2
+elif [[ -z "${SKILLS[$1]}" ]]; then
+  echo "Unknown skill: $1" >&2
+  echo "Available skills: $AVAILABLE_SKILLS" >&2
+  return 1 2>/dev/null || exit 1
 else
   echo "${SKILLS[$1]}"
 fi

--- a/skills/taste-skill/SKILL.md
+++ b/skills/taste-skill/SKILL.md
@@ -47,7 +47,7 @@ LLMs have statistical biases toward specific UI cliché patterns. Proactively co
 * **COLOR CONSISTENCY:** Stick to one palette for the entire output. Do not fluctuate between warm and cool grays within the same project.
 
 **Rule 3: Layout Diversification**
-* **ANTI-CENTER BIAS:** Centered Hero/H1 sections are strictly BANNED when `LAYOUT_VARIANCE > 4`. Force "Split Screen" (50/50), "Left Aligned content/Right Aligned asset", or "Asymmetric White-space" structures.
+* **ANTI-CENTER BIAS:** Centered Hero/H1 sections are strictly BANNED when `DESIGN_VARIANCE > 4`. Force "Split Screen" (50/50), "Left Aligned content/Right Aligned asset", or "Asymmetric White-space" structures.
 
 **Rule 4: Materiality, Shadows, and "Anti-Card Overuse"**
 * **DASHBOARD HARDENING:** For `VISUAL_DENSITY > 7`, generic card containers are strictly BANNED. Use logic-grouping via `border-t`, `divide-y`, or purely negative space. Data metrics should breathe without being boxed in unless elevation (z-index) is functionally required.


### PR DESCRIPTION
## Summary
- Replace the stale `LAYOUT_VARIANCE` reference with the existing `DESIGN_VARIANCE` dial in `taste-skill`.
- Make `skill.sh` return clear errors for empty or unknown skill names instead of succeeding with empty output.

## Validation
- `bash -n skill.sh`
- `bash skill.sh taste-skill`
- `zsh -c 'source ./skill.sh unknown-skill'`
- `git diff --check origin/main...HEAD`