### PR TITLE
fix(v1): rename LAYOUT_VARIANCE to DESIGN_VARIANCE in anti-center rule (#36)

### DIFF
--- a/skills/taste-skill-v1/SKILL.md
+++ b/skills/taste-skill-v1/SKILL.md
@@ -47,7 +47,7 @@ LLMs have statistical biases toward specific UI cliché patterns. Proactively co
 * **COLOR CONSISTENCY:** Stick to one palette for the entire output. Do not fluctuate between warm and cool grays within the same project.
 
 **Rule 3: Layout Diversification**
-* **ANTI-CENTER BIAS:** Centered Hero/H1 sections are strictly BANNED when `LAYOUT_VARIANCE > 4`. Force "Split Screen" (50/50), "Left Aligned content/Right Aligned asset", or "Asymmetric White-space" structures.
+* **ANTI-CENTER BIAS:** Centered Hero/H1 sections are strictly BANNED when `DESIGN_VARIANCE > 4`. Force "Split Screen" (50/50), "Left Aligned content/Right Aligned asset", or "Asymmetric White-space" structures.
 
 **Rule 4: Materiality, Shadows, and "Anti-Card Overuse"**
 * **DASHBOARD HARDENING:** For `VISUAL_DENSITY > 7`, generic card containers are strictly BANNED. Use logic-grouping via `border-t`, `divide-y`, or purely negative space. Data metrics should breathe without being boxed in unless elevation (z-index) is functionally required.


### PR DESCRIPTION
## Summary
Fixes the undefined variable reference in the v1 Anti-Center Bias rule reported in #36. Section 1 defines `DESIGN_VARIANCE`, but Rule 3 checked `LAYOUT_VARIANCE`, so the threshold never applied.

## Problem
In `skills/taste-skill-v1/SKILL.md`:

```markdown
* DESIGN_VARIANCE: 8 (1=Perfect Symmetry, 10=Artsy Chaos)   # Section 1
...
* **ANTI-CENTER BIAS:** ... when `LAYOUT_VARIANCE > 4` ...   # Rule 3 — undefined
```

The v2 default skill already uses `DESIGN_VARIANCE` here and explicitly warns against inventing aliases like `LAYOUT_VARIANCE`.

## Solution
Replace `LAYOUT_VARIANCE` with `DESIGN_VARIANCE` on line 50 so the anti-center rule reads the same dial defined in Section 1.

## Out of scope
- v2 skill (already correct)
- Issue #38 (appendix refactor)
- Broader v1/v2 naming alignment beyond this dead reference

## Test plan
- [x] Grep confirms no remaining `LAYOUT_VARIANCE` in the repo
- [x] Verified Section 1 defines `DESIGN_VARIANCE: 8` and Rule 3 now references the same name

## Related
- #36 — original report

Made with [Cursor](https://cursor.com)