### PR TITLE
fix(stitch-skill): correct dead Google Stitch prerequisite link

### DIFF
--- a/skills/stitch-skill/SKILL.md
+++ b/skills/stitch-skill/SKILL.md
@@ -11,7 +11,7 @@ This skill generates `DESIGN.md` files optimized for Google Stitch screen genera
 The generated `DESIGN.md` serves as the **single source of truth** for prompting Stitch to generate new screens that align with a curated, high-agency design language. Stitch interprets design through **"Visual Descriptions"** supported by specific color values, typography specs, and component behaviors.
 
 ## Prerequisites
-- Access to Google Stitch via [labs.google.com/stitch](https://labs.google.com/stitch)
+- Access to Google Stitch via [labs.google/stitch](https://labs.google/stitch)
 - Optionally: Stitch MCP Server for programmatic integration with Cursor, Antigravity, or Gemini CLI
 
 ## The Goal


### PR DESCRIPTION
The stitch-skill prerequisites link Google Stitch at `https://labs.google.com/stitch`, which returns **404**. The official URL is `https://labs.google/stitch` (no `.com` — it resolves to stitch.withgoogle.com, HTTP 200). This updates both the link text and target so readers reach the live page. One-line change in `skills/stitch-skill/SKILL.md`.