### PR TITLE
fix: add .claude-plugin/ manifest to fix VS Code marketplace install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "taste-skill",
+  "description": "Taste skill library for Claude Code — frontend design, image-to-code, and aesthetic skills",
+  "owner": {
+    "name": "leonxlnx",
+    "email": ""
+  },
+  "plugins": [
+    {
+      "name": "taste-skill",
+      "description": "Frontend design taste skills including brutalist, minimalist, soft, redesign, stitch, and more",
+      "version": "1.0.0",
+      "source": "./",
+      "author": {
+        "name": "leonxlnx",
+        "email": ""
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "taste-skill",
+  "description": "Frontend design taste skills including brutalist, minimalist, soft, redesign, stitch, and more",
+  "version": "1.0.0",
+  "author": {
+    "name": "leonxlnx",
+    "email": ""
+  },
+  "homepage": "https://github.com/leonxlnx/taste-skill",
+  "repository": "https://github.com/leonxlnx/taste-skill",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "frontend",
+    "design",
+    "taste",
+    "ui"
+  ]
+}


### PR DESCRIPTION
## Problem

When trying to add this repo as a marketplace in the **Claude Code VS Code extension**, users get this error:

```
Claude CLI exited with code 1: ✘ Failed to add marketplace: Marketplace file not found at .../.claude-plugin/marketplace.json
```

The Claude Code VS Code extension expects a `.claude-plugin/marketplace.json` file at the root of any repo added as a marketplace. This repo was missing that file entirely.

## Fix

Added the two required files:

- `.claude-plugin/marketplace.json` — registers the plugin catalog (name, description, plugin list)
- `.claude-plugin/plugin.json` — plugin metadata (name, version, author, keywords)

These follow the same structure used by other working marketplaces (e.g. `obra/superpowers`).

## How to verify

1. In VS Code with the Claude Code extension installed, open **Settings → Marketplaces**
2. Add this repo's URL: `https://github.com/leonxlnx/taste-skill`
3. It should now install successfully without the "Marketplace file not found" error