### PR TITLE
docs(readme): document Claude Code plugin marketplace install

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ npx skills add https://github.com/Leonxlnx/taste-skill --skill "design-taste-fro
 
 You can also copy any `SKILL.md` into your project or paste it into ChatGPT / Codex conversations.
 
+### Install as a Claude Code plugin
+
+If you only use Claude Code, you can install the whole repo as a plugin from the included `.claude-plugin/` manifests. Every skill is namespaced under `taste-skill:` (for example, `/taste-skill:imagegen-frontend-web`), so they won't collide with your other skills — no `npx skills` step required.
+
+```bash
+/plugin marketplace add Leonxlnx/taste-skill
+/plugin install taste-skill@taste-skill
+```
+
+Run `/plugin marketplace update taste-skill` later to pull new versions.
+
 ### Updating from the previous version
 
 The default `taste-skill` (install name `design-taste-frontend`) is now **v2 (experimental)**, a substantial rewrite of the original v1. If you already have v1 installed, just re-run the install command and you will be upgraded:

--- a/README.md
+++ b/README.md
@@ -74,12 +74,14 @@ You can also copy any `SKILL.md` into your project or paste it into ChatGPT / Co
 
 If you only use Claude Code, you can install the whole repo as a plugin from the included `.claude-plugin/` manifests. Every skill is namespaced under `taste-skill:` (for example, `/taste-skill:imagegen-frontend-web`), so they won't collide with your other skills — no `npx skills` step required.
 
-```bash
+Run these inside Claude Code:
+
+```
 /plugin marketplace add Leonxlnx/taste-skill
 /plugin install taste-skill@taste-skill
 ```
 
-Run `/plugin marketplace update taste-skill` later to pull new versions.
+Run `/plugin update` later to upgrade installed plugins to new versions. Claude Code also checks for updates automatically at startup.
 
 ### Updating from the previous version
 


### PR DESCRIPTION
## Summary
- Adds an **"Install as a Claude Code plugin"** subsection to `## Installing`, documenting the `/plugin marketplace add` + `/plugin install` path that the existing `.claude-plugin/` manifests already enable.
- Calls out the `taste-skill:` namespace prefix so users know plugin-installed skills won't collide with their other skills.

## Why
The repo already ships valid `.claude-plugin/marketplace.json` and `plugin.json`, but the README only documents the `npx skills add` route — Claude Code users currently have no way to discover that a plugin install path exists.

## Scope
Docs-only. No manifest or skill changes.

## Notes
- Differs from #46, which is currently conflicted (`dirty`) and bundles unrelated skill changes (brandkit, redesign-imagegen-codex). This PR is scoped strictly to README install docs and should merge cleanly.
- Install commands verified locally against Claude Code v2.1.177:
  ```
  /plugin marketplace add Leonxlnx/taste-skill
  /plugin install taste-skill@taste-skill
  ```