### PR TITLE
Enforce prefers-reduced-motion in gpt-taste and minimalist-ui

### DIFF
--- a/skills/gpt-tasteskill/SKILL.md
+++ b/skills/gpt-tasteskill/SKILL.md
@@ -50,6 +50,7 @@ Static interfaces are strictly forbidden. You must write real GSAP (`@gsap/react
 - **Image Scale & Fade Scroll:** Images must start small (`scale: 0.8`). As they scroll into view, they grow to `scale: 1.0`. As they scroll out of view, they smoothly darken and fade out (`opacity: 0.2`).
 - **Scrubbing Text Reveals:** Opacity of central paragraph words starts at 0.1 and scrubs to 1.0 sequentially as the user scrolls.
 - **Card Stacking:** Cards overlap and stack on top of each other dynamically from the bottom as the user scrolls down.
+- **Reduced Motion (mandatory):** Every animation above MUST honor `prefers-reduced-motion: reduce`. Gate ScrollTrigger/GSAP setup behind a reduced-motion check (`gsap.matchMedia()` or `useReducedMotion()`), and under `(prefers-reduced-motion: reduce)` collapse scroll-pinning, scrubbing, image scale/fade, card stacking, and marquees to their static end-state (full opacity, `scale: 1`, no auto-scroll). "Static interfaces are forbidden" governs the default experience, not users who have explicitly requested reduced motion.
 
 ## 6. COMPONENT ARSENAL & CREATIVITY
 Select components from this arsenal based on your randomization:

--- a/skills/minimalist-skill/SKILL.md
+++ b/skills/minimalist-skill/SKILL.md
@@ -73,6 +73,7 @@ Motion should feel invisible — present but never distracting. The goal is quie
 - Staggered Reveals: Lists and grid items enter with a cascade delay (`animation-delay: calc(var(--index) * 80ms)`). Never mount everything at once.
 - Background Ambient Motion: Optional. A single, very slow-moving radial gradient blob (`animation-duration: 20s+`, `opacity: 0.02-0.04`) drifting behind hero sections. Must be applied to a `position: fixed; pointer-events: none` layer. Never on scrolling containers.
 - Performance: Animate exclusively via `transform` and `opacity`. No layout-triggering properties (`top`, `left`, `width`, `height`). Use `will-change: transform` sparingly and only on actively animating elements.
+- Reduced Motion (mandatory): Gate scroll-entry, staggered reveals, and ambient background motion behind `@media (prefers-reduced-motion: no-preference)`, and add a `@media (prefers-reduced-motion: reduce)` block that disables them so content appears instantly at rest. Hover and `:active` feedback may remain.
 
 ## 8. Execution Protocol
 When tasked with writing frontend code (HTML, React, Tailwind, Vue) or designing a layout:


### PR DESCRIPTION
## What
Adds an explicit `prefers-reduced-motion: reduce` mandate to two motion-bearing skills that currently lack one:
- **gpt-tasteskill** (§5 Advanced GSAP Motion) — heavy ScrollTrigger pinning / scrubbing / card-stacking, no reduced-motion fallback.
- **minimalist-skill** (§7 Subtle Motion) — scroll-entry, staggered reveals, ambient drift, no fallback.

## Why
The v2 default `taste-skill` already mandates this in §6.B ("Any motion above `MOTION_INTENSITY > 3` MUST honor `prefers-reduced-motion` … non-negotiable") and its canonical GSAP skeletons use `useReducedMotion()`. The GSAP-heavy `gpt-taste` and the motion-light `minimalist-ui` are the two variants most likely to ship animation without the guard, so this brings them to parity. It's an accessibility correctness fix (WCAG 2.3.3) and avoids vestibular-triggering motion for users who opted out.

For `gpt-taste`, the "static interfaces are forbidden" stance is preserved for the default experience — the rule simply carves out users who explicitly request reduced motion.

## Scope
Docs-only (SKILL.md prompt text); no behavior change for default users.

Noticed while integrating (happy to send separately, kept out to stay focused): the 1–10 dials could be read from an optional project `.taste.json`; the em-dash ban could note it targets rendered UI text; several near-duplicate variants could share a common core.