### PR TITLE
fix(skills): align SKILL.md name to directory name

### DIFF
--- a/skills/brutalist-skill/SKILL.md
+++ b/skills/brutalist-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: industrial-brutalist-ui
+name: brutalist-skill
 description: Raw mechanical interfaces fusing Swiss typographic print with military terminal aesthetics. Rigid grids, extreme type scale contrast, utilitarian color, analog degradation effects. For data-heavy dashboards, portfolios, or editorial sites that need to feel like declassified blueprints.
 ---
 

--- a/skills/gpt-tasteskill/SKILL.md
+++ b/skills/gpt-tasteskill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: gpt-taste
+name: gpt-tasteskill
 description: Elite UX/UI & Advanced GSAP Motion Engineer. Enforces Python-driven true randomization for layout variance, strict AIDA page structure, wide editorial typography (bans 6-line wraps), gapless bento grids, strict GSAP ScrollTriggers (pinning, stacking, scrubbing), inline micro-images, and massive section spacing.
 ---
 

--- a/skills/image-to-code-skill/SKILL.md
+++ b/skills/image-to-code-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: image-to-code
+name: image-to-code-skill
 description: Elite website image-to-code skill for Codex. For visually important web tasks, it must first generate the design image(s) itself, deeply analyze them, then implement the website to match them as closely as possible. In Codex, it must prefer large, readable, section-specific images instead of tiny compressed boards, generate fresh standalone images for sections or detail views instead of cropping old ones, avoid lazy under-generation, avoid cards-inside-cards-inside-cards UI, and keep the hero clean, spacious, readable, and visible on a small laptop.
 ---
 

--- a/skills/minimalist-skill/SKILL.md
+++ b/skills/minimalist-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: minimalist-ui
+name: minimalist-skill
 description: Clean editorial-style interfaces. Warm monochrome palette, typographic contrast, flat bento grids, muted pastels. No gradients, no heavy shadows.
 ---
 

--- a/skills/output-skill/SKILL.md
+++ b/skills/output-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: full-output-enforcement
+name: output-skill
 description: Overrides default LLM truncation behavior. Enforces complete code generation, bans placeholder patterns, and handles token-limit splits cleanly. Apply to any task requiring exhaustive, unabridged output.
 ---
 

--- a/skills/redesign-skill/SKILL.md
+++ b/skills/redesign-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: redesign-existing-projects
+name: redesign-skill
 description: Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without breaking functionality. Works with any CSS framework or vanilla CSS.
 ---
 

--- a/skills/soft-skill/SKILL.md
+++ b/skills/soft-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: high-end-visual-design
+name: soft-skill
 description: Teaches the AI to design like a high-end agency. Defines the exact fonts, spacing, shadows, card structures, and animations that make a website feel expensive. Blocks all the common defaults that make AI designs look cheap or generic.
 ---
 

--- a/skills/stitch-skill/SKILL.md
+++ b/skills/stitch-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: stitch-design-taste
+name: stitch-skill
 description: Semantic Design System Skill for Google Stitch. Generates agent-friendly DESIGN.md files that enforce premium, anti-generic UI standards — strict typography, calibrated color, asymmetric layouts, perpetual micro-motion, and hardware-accelerated performance.
 ---
 

--- a/skills/taste-skill-v1/SKILL.md
+++ b/skills/taste-skill-v1/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: design-taste-frontend-v1
+name: taste-skill-v1
 description: The original v1 taste-skill, preserved for projects depending on its exact behavior. The current default is `design-taste-frontend` (v2 experimental), which is a substantial rewrite. Use this v1 install name only if you need exact backward compatibility.
 ---
 

--- a/skills/taste-skill/SKILL.md
+++ b/skills/taste-skill/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: design-taste-frontend
+name: taste-skill
 description: Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that do not look templated. Real design systems when applicable, audit-first on redesigns, strict pre-flight check.
 ---
 


### PR DESCRIPTION
## Problem

Claude Code identifies skills by their **directory name**. 10 skills in this plugin have a frontmatter `name:` that doesn't match their folder. When the plugin is enabled, Claude Code reports load errors in `/plugins` and the skills can't be invoked by their directory id.

| directory | `name:` before | after |
|---|---|---|
| brutalist-skill | industrial-brutalist-ui | brutalist-skill |
| gpt-tasteskill | gpt-taste | gpt-tasteskill |
| image-to-code-skill | image-to-code | image-to-code-skill |
| minimalist-skill | minimalist-ui | minimalist-skill |
| output-skill | full-output-enforcement | output-skill |
| redesign-skill | redesign-existing-projects | redesign-skill |
| soft-skill | high-end-visual-design | soft-skill |
| stitch-skill | stitch-design-taste | stitch-skill |
| taste-skill-v1 | design-taste-frontend-v1 | taste-skill-v1 |
| taste-skill | design-taste-frontend | taste-skill |

## Change

One-line change per file: align the frontmatter `name:` to the directory name. No descriptions or skill bodies touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)