### PR TITLE
Codex/codex skill compatibility

### DIFF
--- a/skills/brandkit/SKILL.md
+++ b/skills/brandkit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: brandkit
-description: Premium brand-kit image generation skill for creating high-end brand-guidelines boards, logo systems, identity decks, and visual-world presentations. Trained for minimalist, cinematic, editorial, dark-tech, luxury, cultural, security, gaming, developer-tool, and consumer-app brand systems. Optimized for intentional logo concepting, refined composition, sparse typography, strong symbolic meaning, premium mockups, art-directed imagery, and flexible grid layouts.
+description: Use when Codex must generate a brand-kit image, identity board, logo-system direction, palette, typography board, or visual-world presentation for a brand.
 ---
 
 # BRANDKIT IMAGE GENERATION SKILL

--- a/skills/brutalist-skill/SKILL.md
+++ b/skills/brutalist-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: industrial-brutalist-ui
-description: Raw mechanical interfaces fusing Swiss typographic print with military terminal aesthetics. Rigid grids, extreme type scale contrast, utilitarian color, analog degradation effects. For data-heavy dashboards, portfolios, or editorial sites that need to feel like declassified blueprints.
+description: Use when the user requests an industrial, brutalist, Swiss-print, military-terminal, mechanical, or declassified-blueprint visual direction for a dashboard, portfolio, or editorial interface.
 ---
 
 # SKILL: Industrial Brutalism & Tactical Telemetry UI

--- a/skills/gpt-tasteskill/SKILL.md
+++ b/skills/gpt-tasteskill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gpt-taste
-description: Elite UX/UI & Advanced GSAP Motion Engineer. Enforces Python-driven true randomization for layout variance, strict AIDA page structure, wide editorial typography (bans 6-line wraps), gapless bento grids, strict GSAP ScrollTriggers (pinning, stacking, scrubbing), inline micro-images, and massive section spacing.
+description: Use when Codex builds a highly expressive Awwwards-style React interface with deliberate layout variance, GSAP motion, editorial typography, dense bento composition, and strong visual assets.
 ---
 
 # CORE DIRECTIVE: AWWWARDS-LEVEL DESIGN ENGINEERING
@@ -10,14 +10,13 @@ Your goal is to aggressively break these defaults. Your outputs must be highly c
 
 DO NOT USE EMOJIS IN YOUR CODE, COMMENTS, OR OUTPUT. Maintain strictly professional formatting.
 
-## 1. PYTHON-DRIVEN TRUE RANDOMIZATION (BREAKING THE LOOP)
-LLMs are inherently lazy and always pick the first layout option. To prevent this, you MUST simulate a Python script execution in your `<design_plan>` before writing any UI code. 
-Use a deterministic seed (e.g., character count of the user prompt modulo math) to simulate `random.choice()` and strictly select:
+## 1. DETERMINISTIC VARIATION (BREAKING THE LOOP)
+Before writing UI code, derive a stable integer from the brief (for example, the Unicode code-point sum modulo the number of choices). Compute it directly or with an available local tool; never fabricate tool output. Use it to select:
 - 1 Hero Architecture (from Section 3)
 - 1 Typography Stack (Satoshi, Cabinet Grotesk, Outfit, or Geist. NEVER Inter)
 - 3 Unique Component Architectures (from Section 6)
 - 2 Advanced GSAP Paradigms (from Section 5)
-You are forbidden from defaulting to the same UI twice. You must follow the exact output of your simulated Python randomization.
+Do not default to the first option. Record the selected options in a short design plan and follow them unless they conflict with the brief, accessibility, or the existing codebase.
 
 ## 2. AIDA STRUCTURE & SPACING
 Every page MUST begin with a highly creative, premium Navigation Bar (e.g., floating glass pill, or minimal split nav).
@@ -64,9 +63,9 @@ Select components from this arsenal based on your randomization:
 - **Creative Backgrounds:** Inject subtle, professional ambient design. Use deep radial blurs, grainy mesh gradients, or shifting dark overlays. Avoid flat, boring colors.
 - **Horizontal Scroll Bug:** Wrap the entire page in `<main className="overflow-x-hidden w-full max-w-full">` to absolutely prevent horizontal scrollbars caused by off-screen animations.
 
-## 8. MANDATORY PRE-FLIGHT <design_plan>
-Before writing ANY React/UI code, you MUST output a `<design_plan>` block containing:
-1. **Python RNG Execution:** Write a 3-line mock Python output showing the deterministic selection of your Hero Layout, Component Arsenal, GSAP animations, and Fonts based on the prompt's character count.
+## 8. MANDATORY PRE-FLIGHT DESIGN PLAN
+Before writing React/UI code, provide a concise design plan containing:
+1. **Deterministic selection:** State the brief-derived selector and the chosen Hero Layout, Component Arsenal, GSAP animations, and Fonts. Never claim a tool was run unless Codex actually ran it.
 2. **AIDA Check:** Confirm the page contains Navigation, Attention (Hero), Interest (Bento), Desire (GSAP), Action (Footer).
 3. **Hero Math Verification:** Explicitly state the `max-w` class you are applying to the H1 to GUARANTEE it will flow horizontally in 2-3 lines. Confirm NO stamp icons or spam tags exist.
 4. **Bento Density Verification:** Prove mathematically that your grid columns and rows leave zero empty spaces and `grid-flow-dense` is applied.

--- a/skills/gpt-tasteskill/SKILL.md
+++ b/skills/gpt-tasteskill/SKILL.md
@@ -31,7 +31,7 @@ The rest of the page MUST follow the AIDA framework:
 The Hero must breathe. It must NOT be a narrow, 6-line text wall.
 - **The Container Width Fix:** You MUST use ultra-wide containers for the H1 (e.g., `max-w-5xl`, `max-w-6xl`, `w-full`). Allow the words to flow horizontally.
 - **The Line Limit:** The H1 MUST NEVER exceed 2 to 3 lines. 4, 5, or 6 lines is a catastrophic failure. Make the font size smaller (`clamp(3rem, 5vw, 5.5rem)`) and the container wider to ensure this.
-- **Hero Layout Options (Randomly Assigned via Python):**
+- **Hero Layout Options (Deterministically Assigned from the Brief):**
   1. *Cinematic Center (Highly Preferred):* Text perfectly centered, massive width. Below the text, exactly two high-contrast CTAs. Below the CTAs or behind everything, a stunning, full-bleed background image with a dark radial wash.
   2. *Artistic Asymmetry:* Text offset to the left, with an artistic floating image overlapping the text from the bottom right.
   3. *Editorial Split:* Text left, image right, but with massive negative space.

--- a/skills/image-to-code-skill/SKILL.md
+++ b/skills/image-to-code-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: image-to-code
-description: Elite website image-to-code skill for Codex. For visually important web tasks, it must first generate the design image(s) itself, deeply analyze them, then implement the website to match them as closely as possible. In Codex, it must prefer large, readable, section-specific images instead of tiny compressed boards, generate fresh standalone images for sections or detail views instead of cropping old ones, avoid lazy under-generation, avoid cards-inside-cards-inside-cards UI, and keep the hero clean, spacious, readable, and visible on a small laptop.
+description: Use when Codex must generate website reference images and then implement a frontend that closely matches them, especially for visually important landing pages, section-by-section comps, and image-first redesigns.
 ---
 
 # CORE DIRECTIVE: IMAGE-FIRST WEBSITE DESIGN TO CODE

--- a/skills/imagegen-frontend-mobile/SKILL.md
+++ b/skills/imagegen-frontend-mobile/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imagegen-frontend-mobile
-description: Elite mobile app image-generation skill for creating premium, app-native screen concepts and flows. Designed for iOS, Android, and cross-platform mobile products. Prioritizes clean hierarchy, comfortably readable text, strong multi-screen consistency, controlled color palettes, non-generic creative direction, textured surfaces, image-led composition, tasteful custom iconography, and clean phone mockup framing. By default, screens should be shown inside a subtle premium iPhone or similar phone mockup with a visible frame, while the main focus stays on the app content itself. This skill generates images only. It does not write code.
+description: Use when Codex must generate mobile app screen concepts, onboarding flows, multi-screen iOS or Android references, or polished phone-mockup images. This skill generates images only and does not implement code.
 ---
 
 # CORE DIRECTIVE: PREMIUM MOBILE APP IMAGE DIRECTION

--- a/skills/imagegen-frontend-web/SKILL.md
+++ b/skills/imagegen-frontend-web/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imagegen-frontend-web
-description: Elite frontend image-direction skill for generating premium, conversion-aware website design references. CRITICAL OUTPUT RULE — generate ONE separate horizontal image FOR EVERY section. A landing page with 8 sections produces 8 images. Never compress multiple sections into one image. Enforces composition variety (not always left-text / right-image), background-image freedom, varied CTAs, varied hero scales (giant / mid / mini minimalist), narrative concept spine, second-read moments, and a single consistent palette across all images. Optimized for landing pages, marketing sites, and product comps that developers or coding models can accurately recreate.
+description: Use when Codex must generate premium website section images, landing-page comps, marketing references, or product-page visuals as separate implementation-ready horizontal images.
 ---
 
 # HARD OUTPUT RULE — READ FIRST
@@ -16,7 +16,7 @@ description: Elite frontend image-direction skill for generating premium, conver
 
 Each image is one section, generated as its own image call. Never combine multiple sections into one frame. Never return a single tall image that contains the whole page.
 
-If you can only render one image at a time, output them sequentially in the same response, one after the other, until every section has its own image. Announce each one ("Section 1 of 8: Hero", "Section 2 of 8: Trust bar", etc.).
+In Codex, invoke the available image-generation tool once per section and generate the images sequentially. Follow the tool's response protocol; do not add labels, announcements, summaries, or download instructions after an image call when the tool forbids post-generation text.
 
 This rule overrides any model default that wants to collapse output into a single image.
 
@@ -412,7 +412,7 @@ If the request is ambiguous about section count, **default high**:
 - "product page" -> default to 6 sections -> 6 images
 - "portfolio" -> default to 6 sections -> 6 images
 
-If the model can only render one image per call, generate them **sequentially in the same response**, one after the other, labeled "Section X of N: <name>" until the full set is delivered.
+If the model can only render one image per call, generate them **sequentially**, one after the other, until the full set is delivered. In Codex, keep section identity inside each generation prompt instead of emitting text labels around tool results.
 
 ### Format
 - Always horizontal (16:9, 16:10, or 21:9 depending on density)
@@ -915,7 +915,7 @@ For minimalist briefs: this rule is suspended. Restraint is the design.
 When the user asks for a frontend design:
 1. infer site type and primary conversion goal
 2. infer number of sections (if unclear, use the defaults from §5: landing page = 6, full website = 8)
-3. **commit out loud** to the section count and announce it ("Generating N horizontal images, one per section")
+3. commit internally to the section count; do not announce it when Codex's image tool requires no surrounding text
 4. plan ONE horizontal image PER SECTION — always separate generations, never collapse
 5. choose Hero Scale for the whole site (giant / mid / mini)
 5. choose a strong visual combination (theme, type, hero arch, section system, motion, narrative spine, second-read moment)
@@ -928,7 +928,7 @@ When the user asks for a frontend design:
 13. keep spacing generous, even, and clean
 14. remove AI slop (including marquee / fake KPI clichés unless requested)
 15. run §17 CLARITY CHECK
-16. **generate every per-section horizontal image, labeled "Section X of N: <name>"**, until the full set is delivered. Do not stop early. Do not summarize. Do not return only one image.
+16. **generate every per-section horizontal image**, with section identity included in its prompt, until the full set is delivered. Do not stop early, summarize, or return only one image.
 
 Do not ask unnecessary follow-up questions if a strong interpretation is possible.
 

--- a/skills/minimalist-skill/SKILL.md
+++ b/skills/minimalist-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: minimalist-ui
-description: Clean editorial-style interfaces. Warm monochrome palette, typographic contrast, flat bento grids, muted pastels. No gradients, no heavy shadows.
+description: Use when the user requests a minimalist, editorial, restrained, warm-monochrome, muted-pastel, flat-bento, Notion-like, or Linear-like interface without gradients or heavy shadows.
 ---
 
 # Protocol: Premium Utilitarian Minimalism UI Architect

--- a/skills/output-skill/SKILL.md
+++ b/skills/output-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: full-output-enforcement
-description: Overrides default LLM truncation behavior. Enforces complete code generation, bans placeholder patterns, and handles token-limit splits cleanly. Apply to any task requiring exhaustive, unabridged output.
+description: Use when the user explicitly requests complete, exhaustive, unabridged code or multiple deliverables and placeholders, omitted sections, or truncated output would make the result unusable.
 ---
 
 # Full-Output Enforcement

--- a/skills/redesign-skill/SKILL.md
+++ b/skills/redesign-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: redesign-existing-projects
-description: Upgrades existing websites and apps to premium quality. Audits current design, identifies generic AI patterns, and applies high-end design standards without breaking functionality. Works with any CSS framework or vanilla CSS.
+description: Use when Codex must audit and visually redesign an existing website or app while preserving functionality, regardless of CSS framework or vanilla CSS.
 ---
 
 # Redesign Skill

--- a/skills/soft-skill/SKILL.md
+++ b/skills/soft-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: high-end-visual-design
-description: Teaches the AI to design like a high-end agency. Defines the exact fonts, spacing, shadows, card structures, and animations that make a website feel expensive. Blocks all the common defaults that make AI designs look cheap or generic.
+description: Use when the user requests a calm, polished, premium, soft-contrast, high-end-agency visual direction with refined typography, spacing, surfaces, and motion.
 ---
 
 # Agent Skill: Principal UI/UX Architect & Motion Choreographer (Awwwards-Tier)

--- a/skills/stitch-skill/SKILL.md
+++ b/skills/stitch-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stitch-design-taste
-description: Semantic Design System Skill for Google Stitch. Generates agent-friendly DESIGN.md files that enforce premium, anti-generic UI standards — strict typography, calibrated color, asymmetric layouts, perpetual micro-motion, and hardware-accelerated performance.
+description: Use when Codex must create or revise a DESIGN.md specification for Google Stitch screen generation, including visual language, tokens, typography, layout, components, and motion guidance.
 ---
 
 # Stitch Design Taste — Semantic Design System Skill
@@ -12,7 +12,7 @@ The generated `DESIGN.md` serves as the **single source of truth** for prompting
 
 ## Prerequisites
 - Access to Google Stitch via [labs.google/stitch](https://labs.google/stitch)
-- Optionally: Stitch MCP Server for programmatic integration with Cursor, Antigravity, or Gemini CLI
+- Optionally: a configured Stitch MCP server for programmatic integration with Codex or another supported agent
 
 ## The Goal
 Generate a `DESIGN.md` file that encodes:

--- a/skills/taste-skill/SKILL.md
+++ b/skills/taste-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-taste-frontend
-description: Anti-slop frontend skill for landing pages, portfolios, and redesigns. The agent reads the brief, infers the right design direction, and ships interfaces that do not look templated. Real design systems when applicable, audit-first on redesigns, strict pre-flight check.
+description: Use when Codex designs or implements a landing page, portfolio, marketing page, or visual redesign and must avoid generic AI-style layout, typography, spacing, motion, and component choices. Do not use for dashboards, data tables, or multi-step product UI.
 ---
 
 # tasteskill: Anti-Slop Frontend Skill


### PR DESCRIPTION
- The descriptions of the 12 skills read more like promotional copy and do not clearly define their trigger conditions.
- `gpt-taste` requires fabricated Python execution output and a `<design_plan>` block, which does not align with how Codex actually invokes tools.
- `imagegen-frontend-web` requires explanatory text before and after each image, conflicting with the Codex image tool’s rule prohibiting additional text after image generation.