### PR TITLE
fix(skill.sh): align keys with canonical install names

### DIFF
--- a/skill.sh
+++ b/skill.sh
@@ -1,25 +1,46 @@
 #!/usr/bin/env bash
 
-# Local skill registry
+# Local skill registry.
+# Keys are canonical install names (the `name:` field in each SKILL.md frontmatter),
+# matching the install names documented in README.md. Values are SKILL.md paths.
+
+# Detect whether we are being sourced (vs executed directly).
+if [[ -n ${BASH_SOURCE[0]} && ${BASH_SOURCE[0]} != "$0" ]]; then
+  SOURCED=1
+else
+  SOURCED=0
+fi
+
 declare -A SKILLS=(
-  [taste-skill]="skills/taste-skill/SKILL.md"
-  [taste-skill-v1]="skills/taste-skill-v1/SKILL.md"
+  [design-taste-frontend]="skills/taste-skill/SKILL.md"
+  [design-taste-frontend-v1]="skills/taste-skill-v1/SKILL.md"
   [gpt-taste]="skills/gpt-tasteskill/SKILL.md"
-  [image-to-code-skill]="skills/image-to-code-skill/SKILL.md"
+  [image-to-code]="skills/image-to-code-skill/SKILL.md"
   [imagegen-frontend-web]="skills/imagegen-frontend-web/SKILL.md"
   [imagegen-frontend-mobile]="skills/imagegen-frontend-mobile/SKILL.md"
   [brandkit]="skills/brandkit/SKILL.md"
-  [redesign-skill]="skills/redesign-skill/SKILL.md"
-  [soft-skill]="skills/soft-skill/SKILL.md"
-  [output-skill]="skills/output-skill/SKILL.md"
-  [minimalist-skill]="skills/minimalist-skill/SKILL.md"
-  [brutalist-skill]="skills/brutalist-skill/SKILL.md"
-  [stitch-skill]="skills/stitch-skill/SKILL.md"
+  [redesign-existing-projects]="skills/redesign-skill/SKILL.md"
+  [high-end-visual-design]="skills/soft-skill/SKILL.md"
+  [full-output-enforcement]="skills/output-skill/SKILL.md"
+  [minimalist-ui]="skills/minimalist-skill/SKILL.md"
+  [industrial-brutalist-ui]="skills/brutalist-skill/SKILL.md"
+  [stitch-design-taste]="skills/stitch-skill/SKILL.md"
 )
 
-if [[ $# -eq 0 ]]; then
+usage() {
   echo "Usage: source ./skill.sh <skill-name>"
   echo "Available skills: ${!SKILLS[@]}"
-else
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+elif [[ -n ${SKILLS[$1]:-} ]]; then
   echo "${SKILLS[$1]}"
+else
+  usage >&2
+  if (( SOURCED )); then
+    return 1
+  else
+    exit 1
+  fi
 fi


### PR DESCRIPTION
## What

Fixes open issue #76. `skill.sh` keys were an inconsistent mix of folder names and install names. README.md documents that the canonical **Install name** is the `name:` field in each SKILL.md frontmatter (not the folder name), e.g. folder `taste-skill` → install name `design-taste-frontend`.

Keys are now the canonical install names from the README §Skills table (design-taste-frontend, design-taste-frontend-v1, gpt-taste, image-to-code, imagegen-frontend-web, imagegen-frontend-mobile, brandkit, redesign-existing-projects, high-end-visual-design, full-output-enforcement, minimalist-ui, industrial-brutalist-ui, stitch-design-taste), each mapping to the correct SKILL.md path.

Also adds unknown-key handling: usage + available keys printed to stderr and exit 1 (previously an empty line and exit 0), with proper sourced-vs-executed return/exit behavior.

## Verification

- `bash -n skill.sh` passes
- `source ./skill.sh design-taste-frontend` → `skills/taste-skill/SKILL.md`
- `source ./skill.sh bogus-key` → usage to stderr, rc=1
- All 13 keys resolve to existing SKILL.md files

No SKILL.md content, frontmatter names, or README install names were touched.