### PR TITLE
Add native Codex plugin marketplace support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "taste-skill",
+  "interface": {
+    "displayName": "Taste Skill"
+  },
+  "plugins": [
+    {
+      "name": "taste-skill",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/Leonxlnx/taste-skill.git",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Design"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "taste-skill",
+  "version": "1.0.0",
+  "description": "Frontend design taste skills including anti-slop, image-to-code, redesign, and aesthetic workflows.",
+  "author": {
+    "name": "leonxlnx",
+    "url": "https://github.com/Leonxlnx"
+  },
+  "homepage": "https://github.com/Leonxlnx/taste-skill",
+  "repository": "https://github.com/Leonxlnx/taste-skill",
+  "license": "MIT",
+  "keywords": [
+    "skills",
+    "frontend",
+    "design",
+    "taste",
+    "ui"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Taste Skill",
+    "shortDescription": "Anti-slop frontend, image-to-code, and visual design skills.",
+    "longDescription": "Frontend and visual-design skills from Leonxlnx/taste-skill, packaged as one Codex marketplace plugin.",
+    "developerName": "leonxlnx",
+    "category": "Design",
+    "capabilities": [],
+    "websiteURL": "https://github.com/Leonxlnx/taste-skill",
+    "defaultPrompt": [
+      "Design a distinctive frontend without generic AI patterns.",
+      "Redesign this interface while preserving its brand.",
+      "Turn this reference image into production-ready UI."
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ npx skills add https://github.com/Leonxlnx/taste-skill --skill "design-taste-fro
 
 You can also copy any `SKILL.md` into your project or paste it into ChatGPT / Codex conversations.
 
+### Install as a Codex plugin
+
+Codex users can install the complete skill collection as one marketplace plugin:
+
+```bash
+codex plugin marketplace add Leonxlnx/taste-skill
+codex plugin add taste-skill@taste-skill
+```
+
+Start a new Codex session after installation so the bundled skills are loaded.
+
 ### Updating from the previous version
 
 The default `taste-skill` (install name `design-taste-frontend`) is now **v2 (experimental)**, a substantial rewrite of the original v1. If you already have v1 installed, just re-run the install command and you will be upgraded:


### PR DESCRIPTION
## What changed

- add a root `.codex-plugin/plugin.json` that packages the existing `skills/` collection
- add `.agents/plugins/marketplace.json` so Codex can discover the repository with `codex plugin marketplace add`
- document the two Codex CLI installation commands and the new-session pickup step

## Why

The repository already supports Agent Skills and Claude Code plugins, but it does not expose the native Codex plugin manifest or marketplace catalog expected by `codex plugin`.

This PR is intentionally limited to Codex packaging. It complements #64, which adjusts skill instructions for Codex behavior, and does not overlap with that PR's files.

## Validation

- searched all open, closed, and merged PRs for `.codex-plugin`, `.agents/plugins`, and Codex marketplace work; no existing native Codex packaging PR was found
- `jq empty .codex-plugin/plugin.json .agents/plugins/marketplace.json`
- `python3 plugin-creator/scripts/validate_plugin.py <repo>`
- `git diff --check`
- installed the pushed branch through a temporary Git-backed marketplace with Codex CLI 0.147.0
- confirmed all 13 bundled `SKILL.md` files were cached and the installed plugin passed validation
- removed the temporary test plugin and marketplace after verification
