### PR TITLE
Add interfaces.dev as a company sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@
     <td><sub><a href="https://reactbits.dev"><strong>React Bits</strong></a> · animated React components for creative interfaces</sub></td>
   </tr>
   <tr>
+    <td align="center" width="120">
+      <a href="https://interfaces.dev">
+        <picture>
+          <source media="(prefers-color-scheme: dark)" srcset="assets/sponsors/interfaces-dev-logo-dark.svg" />
+          <img src="assets/sponsors/interfaces-dev-logo-light.svg" alt="Interfaces" width="112" />
+        </picture>
+      </a>
+    </td>
+    <td><sub><a href="https://interfaces.dev"><strong>interfaces.dev</strong></a> · the design engineering magazine</sub></td>
+  </tr>
+  <tr>
     <td align="center" width="76"><a href="https://www.sent.dm"><img src="assets/sponsors/sentdm.png" alt="Sent.dm" width="62" height="62" /></a></td>
     <td><sub><a href="https://www.sent.dm"><strong>Sent.dm</strong></a> · messaging APIs for SMS, WhatsApp, and RCS</sub></td>
   </tr>

--- a/assets/sponsors/interfaces-dev-logo-dark.svg
+++ b/assets/sponsors/interfaces-dev-logo-dark.svg
@@ -1,0 +1,4 @@
+<svg width="416" height="80" viewBox="0 0 416 80" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="interfaces-title">
+  <title id="interfaces-title">Interfaces</title>
+  <text x="0" y="59" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="58" font-weight="600" letter-spacing="-2.6">Interfaces</text>
+</svg>

--- a/assets/sponsors/interfaces-dev-logo-light.svg
+++ b/assets/sponsors/interfaces-dev-logo-light.svg
@@ -1,0 +1,4 @@
+<svg width="416" height="80" viewBox="0 0 416 80" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="interfaces-title">
+  <title id="interfaces-title">Interfaces</title>
+  <text x="0" y="59" fill="#111111" font-family="Arial, Helvetica, sans-serif" font-size="58" font-weight="600" letter-spacing="-2.6">Interfaces</text>
+</svg>


### PR DESCRIPTION
## Summary
- add interfaces.dev to the company sponsor table
- link the sponsor to https://interfaces.dev
- include light and dark wordmark assets for GitHub themes

## Verification
- confirmed the sponsor row matches the existing normal company sponsor format
- confirmed both theme assets resolve on the branch