### PR TITLE
Fix interfaces.dev sponsor logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,7 @@
   <tr>
     <td align="center" width="120">
       <a href="https://interfaces.dev">
-        <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="assets/sponsors/interfaces-dev-logo-dark.svg" />
-          <img src="assets/sponsors/interfaces-dev-logo-light.svg" alt="Interfaces" width="112" />
-        </picture>
+        <img src="https://ho1jr3x2dcwdu3t5.public.blob.vercel-storage.com/interfaces-og-image.png" alt="Interfaces" width="112" />
       </a>
     </td>
     <td><sub><a href="https://interfaces.dev"><strong>interfaces.dev</strong></a> · the design engineering magazine</sub></td>

--- a/assets/sponsors/interfaces-dev-logo-dark.svg
+++ b/assets/sponsors/interfaces-dev-logo-dark.svg
@@ -1,4 +1,0 @@
-<svg width="416" height="80" viewBox="0 0 416 80" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="interfaces-title">
-  <title id="interfaces-title">Interfaces</title>
-  <text x="0" y="59" fill="#FFFFFF" font-family="Arial, Helvetica, sans-serif" font-size="58" font-weight="600" letter-spacing="-2.6">Interfaces</text>
-</svg>

--- a/assets/sponsors/interfaces-dev-logo-light.svg
+++ b/assets/sponsors/interfaces-dev-logo-light.svg
@@ -1,4 +1,0 @@
-<svg width="416" height="80" viewBox="0 0 416 80" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="interfaces-title">
-  <title id="interfaces-title">Interfaces</title>
-  <text x="0" y="59" fill="#111111" font-family="Arial, Helvetica, sans-serif" font-size="58" font-weight="600" letter-spacing="-2.6">Interfaces</text>
-</svg>


### PR DESCRIPTION
Replaces the incorrect text-based Interfaces sponsor mark with the official interfaces.dev identity artwork and removes the incorrect generated SVG assets.

This is a draft for visual approval. Do not merge yet.