### PR TITLE
Organize sponsors by tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,27 @@
 
 <h3 align="center">Sponsors</h3>
 
-<p align="center">
-  <a href="https://novamira.ai/" title="Novamira"><img src="https://github.com/use-novamira.png" alt="Novamira" height="56" align="middle" /></a>
-  &nbsp;
-  <strong><a href="https://novamira.ai/">Novamira</a></strong> · Full WordPress access for AI agents
-  &nbsp;&nbsp;&nbsp;&nbsp;
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69mt3v89kkekg24gg" />
-    <img alt="Kimi Open Source Friends" src="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69fudcmosb3pipls0" height="56" align="middle" />
-  </picture>
-</p>
-
 <table align="center">
   <tr>
-    <td align="center" width="76"><a href="https://img.ly/"><img src="assets/sponsors/imgly-logo.svg" alt="IMG.LY" width="62" height="62" /></a></td>
-    <td><sub><a href="https://img.ly/"><strong>IMG.LY</strong></a> · CreativeEditor SDK</sub></td>
+    <td colspan="2"><strong>🥇 Gold Sponsors</strong></td>
   </tr>
   <tr>
-    <td align="center" width="76"><a href="https://animations.dev"><img src="assets/sponsors/animations-dev.webp" alt="animations.dev" width="62" height="62" /></a></td>
-    <td><sub><a href="https://github.com/emilkowalski"><strong>Emil Kowalski</strong></a> · <a href="https://animations.dev">animations.dev</a></sub></td>
+    <td align="center" width="120"><a href="https://novamira.ai/"><img src="https://github.com/use-novamira.png" alt="Novamira" width="62" height="62" /></a></td>
+    <td><sub><a href="https://novamira.ai/"><strong>Novamira</strong></a> · Full WordPress access for AI agents</sub></td>
+  </tr>
+  <tr>
+    <td colspan="2"><strong>🥈 Silver Sponsors</strong></td>
+  </tr>
+  <tr>
+    <td colspan="2"><strong>🥉 Bronze Sponsors</strong></td>
+  </tr>
+  <tr>
+    <td align="center" width="120">
+      <a href="https://interfaces.dev">
+        <img src="https://ho1jr3x2dcwdu3t5.public.blob.vercel-storage.com/interfaces-og-image.png" alt="Interfaces" width="112" />
+      </a>
+    </td>
+    <td><sub><a href="https://interfaces.dev"><strong>interfaces.dev</strong></a> · the design engineering magazine</sub></td>
   </tr>
   <tr>
     <td align="center" width="120">
@@ -46,19 +48,30 @@
     <td><sub><a href="https://reactbits.dev"><strong>React Bits</strong></a> · animated React components for creative interfaces</sub></td>
   </tr>
   <tr>
-    <td align="center" width="120">
-      <a href="https://interfaces.dev">
-        <img src="https://ho1jr3x2dcwdu3t5.public.blob.vercel-storage.com/interfaces-og-image.png" alt="Interfaces" width="112" />
-      </a>
-    </td>
-    <td><sub><a href="https://interfaces.dev"><strong>interfaces.dev</strong></a> · the design engineering magazine</sub></td>
+    <td align="center" width="120"><a href="https://animations.dev"><img src="assets/sponsors/animations-dev.webp" alt="animations.dev" width="62" height="62" /></a></td>
+    <td><sub><a href="https://github.com/emilkowalski"><strong>Emil Kowalski</strong></a> · <a href="https://animations.dev">animations.dev</a></sub></td>
   </tr>
   <tr>
-    <td align="center" width="76"><a href="https://www.sent.dm"><img src="assets/sponsors/sentdm.png" alt="Sent.dm" width="62" height="62" /></a></td>
+    <td align="center" width="120"><a href="https://img.ly/"><img src="assets/sponsors/imgly-logo.svg" alt="IMG.LY" width="62" height="62" /></a></td>
+    <td><sub><a href="https://img.ly/"><strong>IMG.LY</strong></a> · CreativeEditor SDK</sub></td>
+  </tr>
+  <tr>
+    <td align="center" width="120"><a href="https://www.sent.dm"><img src="assets/sponsors/sentdm.png" alt="Sent.dm" width="62" height="62" /></a></td>
     <td><sub><a href="https://www.sent.dm"><strong>Sent.dm</strong></a> · messaging APIs for SMS, WhatsApp, and RCS</sub></td>
   </tr>
   <tr>
-    <td align="center" width="76"><a href="https://vercel.com/open-source-program"><img src="assets/sponsors/vercel-logo.svg" alt="Vercel" width="62" height="62" /></a></td>
+    <td align="center" width="120"><a href="https://www.kimi.com"><img src="https://raw.githubusercontent.com/MoonshotAI/Kimi-K2/main/figures/kimi-logo.png" alt="Kimi" width="62" /></a></td>
+    <td>
+      <a href="https://www.kimi.com">
+        <picture>
+          <source media="(prefers-color-scheme: dark)" srcset="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69mt3v89kkekg24gg" />
+          <img alt="Kimi Open Source Friends" src="https://kimi-file.moonshot.cn/prod-chat-kimi/kfs/4/1/2026-06-05/1d8h69fudcmosb3pipls0" height="40" />
+        </picture>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" width="120"><a href="https://vercel.com/open-source-program"><img src="assets/sponsors/vercel-logo.svg" alt="Vercel" width="62" height="62" /></a></td>
     <td><a href="https://vercel.com/open-source-program"><img src="assets/vercel-oss-program-badge.svg" alt="Vercel Open Source Program" height="32" /></a></td>
   </tr>
 </table>


### PR DESCRIPTION
- move all eight sponsors into one README table
- keep Novamira in Gold and Silver empty
- order Bronze as interfaces.dev, React Bits, Emil Kowalski, IMG.LY, Sent.dm, Kimi, and Vercel
- show Kimi and Vercel with a compact logo plus their full program badge