### PR TITLE
feat: add native mobile product taste workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to taste-skill live here. The repo follows SemVer-ish discip
 ### Repo
 
 - `taste-skill` (install name `design-taste-frontend`) is now **v2 (experimental)**. The previous v1 is preserved as `taste-skill-v1` (install name `design-taste-frontend-v1`).
+- Added `mobile-product-taste`, a progressive audit-to-native workflow for Android and iOS with an approval gate, portable design handoff, deterministic validators, and behavioral evaluation cases.
 - New `CHANGELOG.md` (this file).
 
 ---

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The `Install name` column is the exact value you pass to `--skill`.
 | **gpt-tasteskill** | `gpt-taste` | Stricter variant for GPT/Codex: higher layout variance, stronger GSAP direction, aggressive anti-slop. |
 | **image-to-code-skill** | `image-to-code` | Image-first pipeline: generate site references, analyze them, then implement the frontend to match. |
 | **redesign-skill** | `redesign-existing-projects` | Existing projects: audit the UI first, then fix layout, spacing, hierarchy, styling. |
+| **mobile-product-taste** | `mobile-product-taste` | Native mobile workflow: audit an Android/iOS product, generate coherent screen references, stop for approval, then implement in the existing native stack with a validated design handoff. |
 | **soft-skill** | `high-end-visual-design` | Polished, calm, expensive UI with softer contrast, whitespace, premium fonts, spring motion. |
 | **output-skill** | `full-output-enforcement` | When the model ships half-finished work: full output, no placeholder comments. |
 | **minimalist-skill** | `minimalist-ui` | Editorial product UI (Notion/Linear vibes), restrained palette, crisp structure. |
@@ -171,6 +172,7 @@ These produce design images only (no code). Use with ChatGPT Images, Codex image
 - Use **gpt-taste** when you want the stricter GPT/Codex-oriented rules and motion/layout enforcement. 
 - Use **image-to-code-skill** for image → analyze → code website workflows. 
 - Use **redesign-skill** to improve an existing codebase instead of greenfield styling. 
+- Use **mobile-product-taste** when a native Android or iOS product needs one workflow from audit and prototype approval through implementation and device verification.
 - Add **soft-skill**, **minimalist-skill**, or **brutalist-skill** when the visual direction is already chosen. 
 - Add **output-skill** if the agent keeps truncating output. 
 - Use **imagegen-frontend-web**, **imagegen-frontend-mobile**, or **brandkit** when the deliverable is **images** (comps, flows, identity boards), then pass results to your coding agent.

--- a/research/mobile-product-taste/README.md
+++ b/research/mobile-product-taste/README.md
@@ -1,0 +1,96 @@
+# Mobile Product Taste repair report
+
+## Why this change exists
+
+The first review was made from two separately downloaded files, `redesign-skill` and `imagegen-frontend-mobile`. That partial view correctly exposed a missing handoff, but it understated the full repository. After cloning the repository, the audit found that Taste Skill already had a general web implementation skill, a website image-to-code workflow, and a mobile image-generation skill.
+
+The remaining gap was specific and reproducible:
+
+- `design-taste-frontend` explicitly places native mobile outside its scope.
+- `image-to-code` implements websites, not Android or iOS products.
+- `imagegen-frontend-mobile` deliberately stops at images and defaults to framed presentation renders.
+- `redesign-existing-projects` is largely written around HTML, CSS, browser interaction, and web delivery.
+
+An Android or iOS task therefore had no single portable workflow for audit, coherent multi-screen prototyping, user approval, implementation handoff, native code, and device verification.
+
+## Decision
+
+The repair adds a new installable skill named `mobile-product-taste`. Existing skills and install names remain unchanged. This keeps each established skill's contract stable while filling the native mobile gap.
+
+The new skill uses progressive disclosure:
+
+- `SKILL.md` contains routing, outputs, hard boundaries, and the approval gate.
+- `references/mobile-audit.md` is loaded only for existing products or design reviews.
+- `references/mobile-prototype.md` is loaded only when visual exploration is required.
+- `references/design-handoff.md` defines a portable JSON contract before code work.
+- `references/native-implementation.md` is loaded only for Android or iOS implementation.
+
+## Process
+
+1. Cloned and inspected the full upstream repository instead of relying on the partial local reference.
+2. Located the exact scope boundaries in the existing skills and README.
+3. Added a non-breaking native-mobile workflow with audit, prototype, implement, and full-workflow modes.
+4. Added a hard approval stop between newly generated references and implementation.
+5. Required both framed review renders and raw implementation screens.
+6. Added a JSON handoff with screen IDs, states, tokens, behaviors, approval status, and verification requirements.
+7. Added Android and iOS implementation checks while preserving the existing UI stack.
+8. Added deterministic validators and routing evaluation cases.
+9. Updated the repository registry, discovery summary, README, and changelog.
+
+## Observable effect
+
+| Before | After |
+| --- | --- |
+| Mobile image generation ended without a code-ready contract. | Prototype mode emits raw screens and a validated handoff draft. |
+| Website image-to-code guidance could be misapplied to native apps. | The new description routes Android/iOS tasks and excludes websites. |
+| A phone mockup could become the only implementation reference. | Implementation requires an unframed raw screen for every screen ID. |
+| Implementation could begin while the visual direction was unsettled. | A marked approval gate stops newly generated designs before code. |
+| Native accessibility and system behavior were unspecified. | Android/iOS checks cover touch size, text scaling, system insets, navigation, restoration, and assistive technology. |
+
+## Evaluation
+
+### Deterministic checks
+
+| Check | Result |
+| --- | --- |
+| Codex `quick_validate.py` | PASS |
+| Skill structure and reference routing | PASS, `SKILL.md` is 56 lines |
+| Routing catalog | PASS, 6 cases covering four positive modes and two exclusions |
+| Valid handoff fixture | PASS |
+| Invalid platform and incomplete handoff fixture | Rejected as expected |
+
+Commands used:
+
+```bash
+python path/to/skill-creator/scripts/quick_validate.py skills/mobile-product-taste
+python skills/mobile-product-taste/scripts/validate_skill.py
+python skills/mobile-product-taste/scripts/run_evals.py
+```
+
+### Skill quality review
+
+The planned wrapper scored 52/100 when it had no unified entry, no handoff, no native implementation contract, and no deterministic failure checks. The implemented `mobile-product-taste` scores 96/100 under the same review rubric.
+
+| Dimension | Implemented score |
+| --- | ---: |
+| Trigger precision | 5/5 |
+| Progressive disclosure | 5/5 |
+| Negative space | 5/5 |
+| Output contract | 5/5 |
+| Environment independence | 5/5 |
+| Failure modes | 4/5 |
+| Composability | 4/5 |
+| Instruction enforceability | 5/5 |
+
+The remaining uncertainty is behavioral. Deterministic checks prove structure and contract rejection, not the quality of every model-generated design. Real task evaluations should continue to compare screen consistency, approval-gate compliance, native implementation fidelity, and device evidence across agents.
+
+## Invocation examples
+
+```text
+Use $mobile-product-taste to audit this existing Android flow. Discuss the direction before changing code.
+```
+
+```text
+Use $mobile-product-taste to generate a coherent iOS screen set, wait for approval, then implement the approved direction in the existing project.
+```
+

--- a/skill.sh
+++ b/skill.sh
@@ -8,6 +8,7 @@ declare -A SKILLS=(
   [image-to-code-skill]="skills/image-to-code-skill/SKILL.md"
   [imagegen-frontend-web]="skills/imagegen-frontend-web/SKILL.md"
   [imagegen-frontend-mobile]="skills/imagegen-frontend-mobile/SKILL.md"
+  [mobile-product-taste]="skills/mobile-product-taste/SKILL.md"
   [brandkit]="skills/brandkit/SKILL.md"
   [redesign-skill]="skills/redesign-skill/SKILL.md"
   [soft-skill]="skills/soft-skill/SKILL.md"

--- a/skills/llms.txt
+++ b/skills/llms.txt
@@ -4,6 +4,7 @@ gpt-taste: Elite Awwwards-level frontend design and GSAP motion skill for premiu
 image-to-code-skill: Image-first frontend skill for generating premium website references, deeply analyzing them, and implementing code to match.
 imagegen-frontend-web: Image-generation-only skill for creating premium website design reference images. Does not write code.
 imagegen-frontend-mobile: Image-generation-only skill for creating premium mobile app screen concepts and flows. Does not write code.
+mobile-product-taste: Audit-to-native workflow for Android and iOS products. Produces coherent prototypes, requires visual approval, writes a portable design handoff, and implements in the existing native stack with device evidence.
 brandkit: Image-generation-only skill for creating premium brand-kit overview images with logo concepts, identity systems, color palettes, typography, and mockups. Does not write code.
 redesign-skill: For upgrading existing projects by auditing and fixing design problems.
 soft-skill: Focuses on an expensive, soft UI look with premium fonts, whitespace, depth, and smooth animations.

--- a/skills/mobile-product-taste/SKILL.md
+++ b/skills/mobile-product-taste/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: mobile-product-taste
+description: Audit, prototype, and implement coherent native mobile product interfaces. Use for Android or iOS app redesigns, multi-screen product flows, image-to-native-code work, 移动端改版, 原型稿, or 按照设计稿实现. Do not use for websites, marketing pages, isolated bug fixes, or image-only requests that do not need an implementation handoff.
+metadata:
+  short-description: Mobile audit, prototype, and native implementation
+---
+
+# Mobile Product Taste
+
+Turn a mobile product idea or existing app into an approved visual system, an implementation-ready handoff, and verified native UI. Preserve product logic and user decisions while improving visual quality.
+
+## Choose the mode
+
+Infer the narrowest mode that satisfies the request.
+
+- **Audit** when the user wants critique, direction, or a redesign discussion. Do not edit product code.
+- **Prototype** when the user wants screens, flows, or visual alternatives. Generate images and a handoff draft, then stop for approval.
+- **Implement** when the user approved a prototype, supplied a final reference, or explicitly asked to skip prototyping and build now.
+- **Full workflow** when the user explicitly asks for audit through implementation.
+
+If the platform or requested mode cannot be inferred from the project and brief, ask one decision-changing question. Do not ask for information that repository evidence can answer.
+
+## Workflow
+
+1. Inspect the project, references, existing design assets, platform, UI stack, primary flow, and required states.
+2. State a one-line design read and create or update `.taste/mobile-design-brief.md` in the target project.
+3. For an existing product, read [references/mobile-audit.md](references/mobile-audit.md) and record an evidence-based audit before proposing changes.
+4. For visual exploration, read [references/mobile-prototype.md](references/mobile-prototype.md). Produce a coherent screen set, not a single decorative board.
+5. ⛔ **Approval gate:** do not implement from newly generated references until the user approves a direction. A direct request to implement now counts as approval to skip this gate.
+6. Before implementation, read [references/design-handoff.md](references/design-handoff.md). Write `.taste/mobile-design-handoff.json` and run `scripts/validate_handoff.py`.
+7. For native code, read [references/native-implementation.md](references/native-implementation.md). Work in the existing stack, preserve behavior, and verify on the relevant emulator or device.
+8. Report changed screens, preserved behavior, verification evidence, and any remaining visual uncertainty.
+
+## Required outputs
+
+| Mode | Verifiable output |
+| --- | --- |
+| Audit | `.taste/mobile-design-brief.md` with evidence, constraints, and screen/state inventory |
+| Prototype | Review images plus implementation-ready raw screens and a handoff draft |
+| Implement | Valid handoff, code changes, automated checks, and emulator/device evidence |
+| Full workflow | All outputs above, separated by the approval gate |
+
+## Hard boundaries
+
+- Do not copy a reference image blindly. Extract its hierarchy, spacing, type, color, shape, and motion rules.
+- Do not invent missing product behavior to make a screen look complete. Mark unresolved behavior in the handoff.
+- Do not change navigation, permissions, data handling, labels with product meaning, or accessibility behavior silently.
+- Do not import a new UI library until the existing dependency and design-system choices are checked.
+- Do not treat a phone mockup as an implementation reference. Implementation references must also exist without a device frame.
+- If image generation fails twice, stop generating, keep the written design system, and offer a code-native prototype or a retry later.
+- If a build or device check cannot run, state the exact unverified layer. Do not claim visual parity.
+
+## Final check
+
+Confirm that every required state has a screen, all screens share one visual system, touch and text accessibility pass, the handoff validator passes, and the final report distinguishes observed evidence from judgment.
+

--- a/skills/mobile-product-taste/agents/openai.yaml
+++ b/skills/mobile-product-taste/agents/openai.yaml
@@ -1,0 +1,8 @@
+interface:
+  display_name: "Mobile Product Taste"
+  short_description: "Audit, prototype, and implement native mobile UI"
+  brand_color: "#1F6B57"
+  default_prompt: "Use $mobile-product-taste to review this mobile product flow, prototype a coherent direction, and prepare an implementation-ready handoff."
+policy:
+  allow_implicit_invocation: true
+

--- a/skills/mobile-product-taste/evals/cases.json
+++ b/skills/mobile-product-taste/evals/cases.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "cases": [
+    {
+      "id": "android-existing-discussion",
+      "request": "先审查这个 Android 应用的现有页面，我们讨论清楚再改代码。",
+      "shouldTrigger": true,
+      "expectedMode": "audit",
+      "requiredBehavior": ["inspect-existing-project", "write-brief", "no-code-edit"]
+    },
+    {
+      "id": "android-prototype-gate",
+      "request": "为这个 Android 注意力应用生成完整原型，确认后再实现。",
+      "shouldTrigger": true,
+      "expectedMode": "prototype",
+      "requiredBehavior": ["review-renders", "raw-screens", "stop-for-approval"]
+    },
+    {
+      "id": "approved-image-to-compose",
+      "request": "这些页面已经确认，按照原型在现有 Jetpack Compose 项目中实现并真机验证。",
+      "shouldTrigger": true,
+      "expectedMode": "implement",
+      "requiredBehavior": ["write-handoff", "validate-handoff", "preserve-stack", "device-evidence"]
+    },
+    {
+      "id": "explicit-full-workflow",
+      "request": "完成移动端审美审查、出原型、等我确认，再落地到原生应用。",
+      "shouldTrigger": true,
+      "expectedMode": "full-workflow",
+      "requiredBehavior": ["audit", "prototype", "approval-gate", "implementation"]
+    },
+    {
+      "id": "website-exclusion",
+      "request": "重新设计我的 SaaS 落地页并用 Next.js 实现。",
+      "shouldTrigger": false,
+      "expectedMode": null,
+      "requiredBehavior": ["route-to-web-design-skill"]
+    },
+    {
+      "id": "non-visual-bug-exclusion",
+      "request": "修复 Android 数据库迁移导致的启动崩溃。",
+      "shouldTrigger": false,
+      "expectedMode": null,
+      "requiredBehavior": ["route-to-debugging"]
+    }
+  ]
+}
+

--- a/skills/mobile-product-taste/evals/invalid-handoff.json
+++ b/skills/mobile-product-taste/evals/invalid-handoff.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "revision": "draft-1",
+  "platform": "web",
+  "uiStack": "unknown",
+  "designRead": "Invalid fixture",
+  "approval": {
+    "status": "pending"
+  },
+  "tokens": {},
+  "screens": [],
+  "verification": {}
+}
+

--- a/skills/mobile-product-taste/evals/valid-handoff.json
+++ b/skills/mobile-product-taste/evals/valid-handoff.json
@@ -1,0 +1,37 @@
+{
+  "schemaVersion": 1,
+  "revision": "approved-1",
+  "platform": "android",
+  "uiStack": "jetpack-compose",
+  "designRead": "A quiet native utility with one deliberate action per screen.",
+  "approval": {
+    "status": "approved",
+    "source": "user",
+    "approvedAt": "2026-08-31"
+  },
+  "tokens": {
+    "colors": {},
+    "typography": {},
+    "spacing": {},
+    "shapes": {},
+    "motion": {}
+  },
+  "screens": [
+    {
+      "id": "entry-purpose",
+      "purpose": "Ask for intent before entering a managed app.",
+      "states": ["default", "large-text"],
+      "reviewImage": "prototypes/entry-purpose-frame.png",
+      "rawImage": "prototypes/entry-purpose-raw.png",
+      "components": ["purpose-option"],
+      "behaviors": ["system-back-dismisses"],
+      "openQuestions": []
+    }
+  ],
+  "verification": {
+    "viewports": ["small", "representative"],
+    "accessibility": ["large-text", "screen-reader"],
+    "requiredDeviceChecks": []
+  }
+}
+

--- a/skills/mobile-product-taste/references/design-handoff.md
+++ b/skills/mobile-product-taste/references/design-handoff.md
@@ -1,0 +1,61 @@
+# Design handoff
+
+Read this file before implementing or handing an approved mobile design to another coding agent.
+
+Create `.taste/mobile-design-handoff.json` in the target project. Use JSON so any agent or validation script can consume it without an extra parser.
+
+## Required shape
+
+```json
+{
+  "schemaVersion": 1,
+  "revision": "approved-1",
+  "platform": "android",
+  "uiStack": "jetpack-compose",
+  "designRead": "A calm attention utility for deliberate interruption.",
+  "approval": {
+    "status": "approved",
+    "source": "user",
+    "approvedAt": "2026-08-31"
+  },
+  "tokens": {
+    "colors": {},
+    "typography": {},
+    "spacing": {},
+    "shapes": {},
+    "motion": {}
+  },
+  "screens": [
+    {
+      "id": "entry-purpose",
+      "purpose": "Ask for intent before opening a managed app.",
+      "states": ["default", "large-text"],
+      "reviewImage": "prototypes/entry-purpose-frame.png",
+      "rawImage": "prototypes/entry-purpose-raw.png",
+      "components": ["purpose-option", "duration-control"],
+      "behaviors": ["system-back-dismisses"],
+      "openQuestions": []
+    }
+  ],
+  "verification": {
+    "viewports": ["small", "representative"],
+    "accessibility": ["large-text", "screen-reader"],
+    "requiredDeviceChecks": []
+  }
+}
+```
+
+## Rules
+
+- `approval.status` must be `approved` before implementation. Use `draft` during exploration.
+- Every implementation screen needs a stable `id`, purpose, state list, component list, and raw image.
+- Keep unresolved product behavior in `openQuestions`; do not resolve it through visual guesswork.
+- Use repository-relative image paths. Do not embed local absolute paths or temporary image-generation locations.
+- Increment `revision` whenever an approved image, token, component contract, or behavior changes.
+
+Validate the file with:
+
+```bash
+python skills/mobile-product-taste/scripts/validate_handoff.py path/to/.taste/mobile-design-handoff.json
+```
+

--- a/skills/mobile-product-taste/references/mobile-audit.md
+++ b/skills/mobile-product-taste/references/mobile-audit.md
@@ -1,0 +1,54 @@
+# Mobile audit
+
+Read this file only for an existing app or an explicit design review.
+
+## Evidence first
+
+Inspect the running app when possible. Pair screenshots with code evidence so the audit can distinguish visual symptoms from implementation constraints. Record the platform, UI framework, theme/token source, navigation model, supported device classes, and accessibility constraints.
+
+## Screen and state inventory
+
+List the primary journey in order. For each screen, record the states that can actually occur.
+
+- initial, returning, empty, populated, loading, error, disabled, permission denied
+- keyboard open, long text, large text, offline, interrupted, and back navigation
+- light/dark mode only when the product supports both
+
+Missing states are product risks, not decoration tasks.
+
+## Audit lenses
+
+### Product hierarchy
+
+- Can a user identify the current state, the next action, and the way back without reading explanatory prose?
+- Does the primary action match the product's decision, or merely carry the brightest color?
+- Are repeated confirmations, dead ends, and unnecessary app launches visible in the journey?
+
+### Platform fit
+
+- Respect system bars, display cutouts, keyboard insets, back behavior, and platform navigation conventions.
+- Check tap targets, text scaling, focus order, screen reader labels, contrast, and state announcements.
+- Separate platform conventions from brand choices. A brand may change color and form; it should not make system behavior surprising.
+
+### Visual system
+
+- Identify the real type scale, spacing rhythm, color roles, radius rules, icon family, elevation rules, and motion language.
+- Flag generic AI patterns only when evidence shows they weaken hierarchy or identity. Do not replace one trend with another.
+- Check whether visual density matches the task. A focused decision screen and a browsing screen may need different density within one system.
+
+### Implementation health
+
+- Locate duplicated values, one-off styles, inconsistent components, and layout constants that break on another device.
+- Preserve stable functionality. Prefer tokens and reusable components when at least two screens share the same decision.
+
+## Audit output
+
+Write the following into `.taste/mobile-design-brief.md`.
+
+1. One-line design read
+2. Product and platform constraints
+3. Current journey and state inventory
+4. Evidence-backed problems, ordered by user impact
+5. Visual direction with preserved elements
+6. Open decisions that would materially change the result
+

--- a/skills/mobile-product-taste/references/mobile-prototype.md
+++ b/skills/mobile-product-taste/references/mobile-prototype.md
@@ -1,0 +1,42 @@
+# Mobile prototype
+
+Read this file when visual references or multiple screen concepts are requested.
+
+## Lock a design bible
+
+Before generating screens, define and keep stable:
+
+- platform and target aspect ratio
+- product mood and audience
+- type roles and minimum readable size
+- neutral palette, semantic colors, and one controlled accent family
+- spacing rhythm, shape rules, icon language, and surface treatment
+- navigation, sheets, overlays, keyboard behavior, and motion language
+
+The design bible may be revised after review. Do not let individual generations drift silently.
+
+## Generate the journey
+
+Generate the smallest screen set that makes the requested journey believable. Include meaningful alternate states. A multi-step flow requires separate screens; do not compress it into a collage unless the user asked for a board.
+
+For each approved screen, retain two outputs when implementation will follow.
+
+1. **Review render** with a subtle platform-appropriate device frame or contextual presentation.
+2. **Raw screen** without a device frame, reflections, perspective, hands, scenery, or decorative labels outside the app surface.
+
+Use an Android frame for Android products and an iPhone frame for iOS products. If the platform is unspecified, use a neutral frame and mark the assumption.
+
+## Readability and consistency
+
+- Keep primary text comfortably readable at phone size. Split a screen rather than shrinking important text.
+- Respect safe areas and reachable action placement.
+- Use real draft copy from the product context. Do not use lorem ipsum or decorative fake data.
+- Keep the same palette, typography, icon logic, component anatomy, and device geometry across the set.
+- Vary screen composition only where the task changes.
+
+## Review loop
+
+Inspect every generated image before delivery. Regenerate a screen when text is malformed, the device frame is wrong, hierarchy is unclear, content is clipped, or the design bible drifted.
+
+⛔ Stop after presenting the coherent set. Ask for approval of the direction before implementation unless the user already authorized implementation.
+

--- a/skills/mobile-product-taste/references/native-implementation.md
+++ b/skills/mobile-product-taste/references/native-implementation.md
@@ -1,0 +1,34 @@
+# Native implementation
+
+Read this file only when implementing an approved design in Android or iOS code.
+
+## Shared rules
+
+- Confirm the approved screen IDs and handoff revision before editing UI code.
+- Reuse the current language, UI framework, navigation, and state model.
+- Map the handoff to tokens and reusable components before tuning individual screens.
+- Preserve loading, empty, error, permission, keyboard, interruption, and back states.
+- Use platform typography scaling and semantic accessibility labels. Do not encode meaningful text inside bitmap assets.
+- Animate transforms, opacity, masks, or platform-native drawing primitives. Provide a low-motion result where the platform exposes that preference.
+- Verify at the smallest supported viewport, a representative viewport, large text, and the product's required theme modes.
+
+## Android
+
+- Detect Compose, Views/XML, or a hybrid before editing. Do not migrate UI frameworks for a visual redesign.
+- Use `dp` for layout and touch geometry and `sp` or scalable typography APIs for text.
+- Keep interactive targets at least 48 × 48 dp unless a larger product-specific minimum exists.
+- Handle status bars, navigation bars, display cutouts, IME insets, predictive/back navigation, and activity recreation.
+- Prefer theme tokens and semantic colors over repeated literals. In Compose, keep state ownership and recomposition boundaries stable; in Views, preserve lifecycle and saved-state behavior.
+- Check TalkBack order and labels. Verify overlays, sheets, dialogs, and permission recovery on a real device when they depend on system behavior.
+
+## iOS
+
+- Detect SwiftUI, UIKit, or a hybrid before editing. Do not migrate frameworks for appearance alone.
+- Respect safe areas, Dynamic Type, VoiceOver order, keyboard avoidance, scene restoration, and system back/dismiss conventions.
+- Keep interactive targets at least 44 × 44 pt unless a larger product-specific minimum exists.
+- Prefer semantic colors and text styles. Preserve environment-driven state and navigation ownership.
+
+## Verification evidence
+
+Run existing tests first, then the narrowest tests that cover changed components and flows. Capture screenshots or recordings from the actual emulator/device. Compare against the raw screen reference while allowing platform rendering differences. Document every intentional deviation in the final report and handoff revision.
+

--- a/skills/mobile-product-taste/scripts/run_evals.py
+++ b/skills/mobile-product-taste/scripts/run_evals.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Run deterministic contract and evaluation-catalog checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from validate_handoff import validate
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EVALS = ROOT / "evals"
+ALLOWED_MODES = {"audit", "prototype", "implement", "full-workflow", None}
+
+
+def main() -> int:
+    catalog = json.loads((EVALS / "cases.json").read_text(encoding="utf-8"))
+    cases = catalog.get("cases", [])
+    assert catalog.get("schemaVersion") == 1
+    assert len(cases) >= 6
+    ids = [case["id"] for case in cases]
+    assert len(ids) == len(set(ids))
+    assert all(case.get("expectedMode") in ALLOWED_MODES for case in cases)
+    assert any(not case.get("shouldTrigger") for case in cases)
+    assert any(case.get("expectedMode") == "full-workflow" for case in cases)
+    assert any("stop-for-approval" in case.get("requiredBehavior", []) for case in cases)
+
+    validate(EVALS / "valid-handoff.json")
+    invalid_rejected = False
+    try:
+        validate(EVALS / "invalid-handoff.json")
+    except ValueError:
+        invalid_rejected = True
+    assert invalid_rejected
+
+    print(f"PASS: {len(cases)} routing cases and 2 handoff fixtures")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/skills/mobile-product-taste/scripts/validate_handoff.py
+++ b/skills/mobile-product-taste/scripts/validate_handoff.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate the portable mobile design handoff contract."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REQUIRED_TOP_LEVEL = {
+    "schemaVersion",
+    "revision",
+    "platform",
+    "uiStack",
+    "designRead",
+    "approval",
+    "tokens",
+    "screens",
+    "verification",
+}
+REQUIRED_TOKEN_GROUPS = {"colors", "typography", "spacing", "shapes", "motion"}
+REQUIRED_SCREEN_FIELDS = {
+    "id",
+    "purpose",
+    "states",
+    "reviewImage",
+    "rawImage",
+    "components",
+    "behaviors",
+    "openQuestions",
+}
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def validate(path: Path) -> None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail(f"handoff file not found: {path}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}")
+
+    missing = REQUIRED_TOP_LEVEL - data.keys()
+    if missing:
+        fail(f"missing top-level fields: {', '.join(sorted(missing))}")
+    if data["schemaVersion"] != 1:
+        fail("schemaVersion must be 1")
+    if data["platform"] not in {"android", "ios", "cross-platform"}:
+        fail("platform must be android, ios, or cross-platform")
+
+    approval = data["approval"]
+    if not isinstance(approval, dict) or approval.get("status") not in {"draft", "approved"}:
+        fail("approval.status must be draft or approved")
+
+    tokens = data["tokens"]
+    if not isinstance(tokens, dict):
+        fail("tokens must be an object")
+    missing_tokens = REQUIRED_TOKEN_GROUPS - tokens.keys()
+    if missing_tokens:
+        fail(f"missing token groups: {', '.join(sorted(missing_tokens))}")
+
+    screens = data["screens"]
+    if not isinstance(screens, list) or not screens:
+        fail("screens must contain at least one screen")
+    seen_ids: set[str] = set()
+    for index, screen in enumerate(screens):
+        if not isinstance(screen, dict):
+            fail(f"screens[{index}] must be an object")
+        missing_screen = REQUIRED_SCREEN_FIELDS - screen.keys()
+        if missing_screen:
+            fail(f"screens[{index}] missing fields: {', '.join(sorted(missing_screen))}")
+        screen_id = screen["id"]
+        if not isinstance(screen_id, str) or not screen_id.strip():
+            fail(f"screens[{index}].id must be a non-empty string")
+        if screen_id in seen_ids:
+            fail(f"duplicate screen id: {screen_id}")
+        seen_ids.add(screen_id)
+        if not isinstance(screen["states"], list) or not screen["states"]:
+            fail(f"screens[{index}].states must be a non-empty list")
+        if not isinstance(screen["rawImage"], str) or not screen["rawImage"].strip():
+            fail(f"screens[{index}].rawImage is required for implementation")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: validate_handoff.py <mobile-design-handoff.json>", file=sys.stderr)
+        return 2
+    try:
+        validate(Path(argv[1]))
+    except (OSError, ValueError) as exc:
+        print(f"INVALID: {exc}", file=sys.stderr)
+        return 1
+    print("VALID")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))
+

--- a/skills/mobile-product-taste/scripts/validate_skill.py
+++ b/skills/mobile-product-taste/scripts/validate_skill.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Run deterministic structural checks for mobile-product-taste."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "SKILL.md"
+REQUIRED = [
+    ROOT / "references" / "mobile-audit.md",
+    ROOT / "references" / "mobile-prototype.md",
+    ROOT / "references" / "native-implementation.md",
+    ROOT / "references" / "design-handoff.md",
+    ROOT / "evals" / "cases.json",
+    ROOT / "agents" / "openai.yaml",
+]
+
+
+def main() -> int:
+    errors: list[str] = []
+    text = SKILL.read_text(encoding="utf-8")
+    line_count = len(text.splitlines())
+    if line_count > 100:
+        errors.append(f"SKILL.md has {line_count} lines; maximum is 100")
+    if not re.search(r"^name:\s+mobile-product-taste$", text, re.MULTILINE):
+        errors.append("frontmatter name must be mobile-product-taste")
+    if "⛔ **Approval gate:**" not in text:
+        errors.append("approval hard stop is missing")
+    for path in REQUIRED:
+        if not path.is_file():
+            errors.append(f"required file is missing: {path.relative_to(ROOT)}")
+        elif path.suffix == ".md" and path.name != "SKILL.md":
+            expected_link = f"({path.relative_to(ROOT).as_posix()})"
+            if expected_link not in text:
+                errors.append(f"SKILL.md does not route to {path.relative_to(ROOT)}")
+    if any(marker in text for marker in ("TODO", "TBD", "Example placeholder")):
+        errors.append("unfinished scaffold marker found")
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}")
+        return 1
+    print(f"PASS: mobile-product-taste structure is valid ({line_count} lines)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary

- add mobile-product-taste as an audit-to-native workflow for Android and iOS
- add an approval gate, raw-screen requirement, portable JSON handoff, and native implementation guidance
- add deterministic structure, routing, and handoff validation
- document the gap, design decisions, observed effect, and evaluation limits

## Validation

- Codex quick_validate.py
- python skills/mobile-product-taste/scripts/validate_skill.py
- python skills/mobile-product-taste/scripts/run_evals.py
- valid handoff accepted and invalid handoff rejected

Existing skill names and behavior remain unchanged.