### PR TITLE
feat: add Codex plugin packaging

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "taste-skill",
+  "interface": {
+    "displayName": "Taste Skill"
+  },
+  "plugins": [
+    {
+      "name": "taste-skill",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "taste-skill",
+  "version": "1.0.0",
+  "description": "Anti-slop frontend design skills for Codex, from art direction and redesigns to image-to-code workflows.",
+  "author": {
+    "name": "Leonxlnx",
+    "url": "https://github.com/Leonxlnx"
+  },
+  "homepage": "https://tasteskill.dev",
+  "repository": "https://github.com/Leonxlnx/taste-skill",
+  "license": "MIT",
+  "keywords": [
+    "frontend",
+    "design",
+    "ui",
+    "ux",
+    "agent-skills"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Taste Skill",
+    "shortDescription": "Anti-slop frontend design skills for Codex.",
+    "longDescription": "A collection of frontend design skills for stronger layouts, typography, motion, redesigns, art direction, and image-to-code workflows.",
+    "developerName": "Leonxlnx",
+    "category": "Productivity",
+    "capabilities": [
+      "Frontend design",
+      "Image generation",
+      "Image-to-code"
+    ],
+    "websiteURL": "https://tasteskill.dev",
+    "defaultPrompt": [
+      "Apply Taste Skill to design this frontend.",
+      "Redesign this interface with a stronger visual direction.",
+      "Turn this reference image into a polished frontend."
+    ],
+    "brandColor": "#111827",
+    "composerIcon": "./assets/taste-skill-logo.png",
+    "logo": "./assets/taste-skill-logo.png"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to taste-skill live here. The repo follows SemVer-ish discip
 
 ### Repo
 
+- Added a Codex plugin manifest and repo marketplace so the full skill collection can be installed with `codex plugin`.
 - `taste-skill` (install name `design-taste-frontend`) is now **v2 (experimental)**. The previous v1 is preserved as `taste-skill-v1` (install name `design-taste-frontend-v1`).
 - New `CHANGELOG.md` (this file).
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ npx skills add https://github.com/Leonxlnx/taste-skill --skill "design-taste-fro
 
 You can also copy any `SKILL.md` into your project or paste it into ChatGPT / Codex conversations.
 
+### Installing in Codex as a plugin
+
+This repo also includes a Codex plugin manifest and marketplace entry, so you can install all bundled skills as one plugin without copying individual `SKILL.md` files.
+
+1. Add this GitHub repository as a Codex marketplace:
+
+```bash
+codex plugin marketplace add Leonxlnx/taste-skill
+```
+
+2. Install the plugin from that marketplace:
+
+```bash
+codex plugin add taste-skill@taste-skill
+```
+
+3. Start a new Codex task after installing so the newly added skills are picked up cleanly.
+
+For local development, run `codex plugin marketplace add .` from the repository root instead. The marketplace definition lives at `.agents/plugins/marketplace.json`, and the Codex plugin manifest lives at `.codex-plugin/plugin.json`.
+
 ### Updating from the previous version
 
 The default `taste-skill` (install name `design-taste-frontend`) is now **v2 (experimental)**, a substantial rewrite of the original v1. If you already have v1 installed, just re-run the install command and you will be upgraded:


### PR DESCRIPTION
## Summary

Make Taste Skill installable in Codex as a plugin and expose the existing skill collection through a repository marketplace.

## Changes

- add the Codex plugin manifest at `.codex-plugin/plugin.json`
- add the repository marketplace at `.agents/plugins/marketplace.json`
- document GitHub and local Codex installation flows
- record the new packaging support in the changelog

## Validation

- plugin-creator validator passes for all 13 bundled skills
- both JSON files pass `python3 -m json.tool`
- `git diff --check` passes
